### PR TITLE
Remove dependency on GTA5 directory

### DIFF
--- a/src/scripts/Config.nsh
+++ b/src/scripts/Config.nsh
@@ -4,7 +4,7 @@
 !define NAME "FiveM ReShade"
 !define UNINSTALLER "Uninstall Reshade for FiveM.exe"
 !define UPDATELINK "https://github.com/bituq/FiveRFX"
-!define GRAPHICSAPI "dxgi"
+!define GRAPHICSAPI "d3d11"
 !define HASHSTRINGEXE "..\..\hash_string\target\release\hash_string.exe"
 
 VIProductVersion "${VERSION}.0"

--- a/src/scripts/Config.nsh
+++ b/src/scripts/Config.nsh
@@ -1,5 +1,5 @@
-!define RESHADE_VERSION "6.0.0"
-!define VERSION "1.0.1"
+!define RESHADE_VERSION "6.0.1"
+!define VERSION "1.0.2"
 !define MANUFACTURER "Dylan N"
 !define NAME "FiveM ReShade"
 !define UNINSTALLER "Uninstall Reshade for FiveM.exe"

--- a/src/scripts/Main.nsi
+++ b/src/scripts/Main.nsi
@@ -22,6 +22,7 @@ Function .onInit
     DetailPrint "$TEMP\$0.log"
 
     ; Locate the FiveM directory
+    Var /GLOBAL FiveMDirectory
     ReadRegStr $0 HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\CitizenFX_FiveM" "InstallLocation"
     ${If} $0 == ""
         !insertmacro LogAndPrint "Unable to locate the FiveM directory."
@@ -38,12 +39,7 @@ Section
     SetOutPath $PLUGINSDIR
     File ${HASHSTRINGEXE}
 
-    ; Locate GTA 5
-    ReadINIStr $0 "$0\FiveM.app\CitizenFX.ini" "Game" "IVPath"
-    IfFileExists "$0\*.*" +3
-        !insertmacro LogAndPrint "GTA 5 location: $0"
-    MessageBox MB_ICONSTOP|MB_OK "Unable to locate GTA 5. Please ensure that GTA 5 is installed." /SD IDOK
-    Quit
+    ExecWait '"$PLUGINSDIR\hash_string.exe" "$0\FiveM.app\CitizenFX.ini"'
 
     ; Set the update channel to beta if needed
     ReadINIStr $1 "$0\FiveM.app\CitizenFX.ini" "Game" "UpdateChannel"
@@ -81,6 +77,7 @@ Section
     FindFirst $R1 $R2 "$PLUGINSDIR\reshade\*.*"
     loop:
         StrCmp $R2 "" done
+        StrCmp $R2 "." +3
         CopyFiles "$PLUGINSDIR\reshade\$R2" "$1\$R2"
         !insertmacro LogAndPrint "Moving $R2"
         FindNext $R1 $R2


### PR DESCRIPTION
This commit introduces a couple of significant changes to the installation script. Firstly, it removes the previous method of locating the GTA 5 directory since it is not required.

Additionally, the `FiveMDirectory` variable has been declared as GLOBAL to ensure its availability throughout the script, which improves the maintainability and readability of the code by using a consistent reference to the FiveM directory.

Lastly, a check for the current directory entry being "." is added in the reshade files copying loop to prevent unnecessary operations on the current directory reference.